### PR TITLE
Update gcc-11.2.0 and glibc-2.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ sudo apt install build-essential
 # libssl-dev is needed by the latest kernels...
 sudo apt-get install libssl-dev 
 
+# autoconf is needed by samba...
+sudo apt-get install autoconf
+
 # Git is needed to checkout LinuxFromScratch
 sudo apt install git
 

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Cross compiler and Linux generation scripts
+# (c)2021 Sebastien CORBEAU
+#
+# patch function
+#
+
+function apply_patches()
+{
+	if [ -d $1 ]; then
+		if [ ! -z "$(ls -A $1)" ]; then
+			for p in $1/*patch ; do
+				patch -p1 < $p
+			done
+		fi
+	fi
+}

--- a/scripts/bs_network.sh
+++ b/scripts/bs_network.sh
@@ -10,6 +10,8 @@ source ${SCRIPTS_HOME}/unpack.sh || exit 1
 
 source ${TARGET_CONFIG}/config.sh || exit 1
 
+source ${SCRIPTS_HOME}/apply_patches.sh || exit 1
+
 echo "***********"
 echo "* Network *"
 echo "***********"
@@ -137,6 +139,8 @@ then
 		unpack ${CUR_PACKAGE} ""
 
 		cd ${TARGET_SOURCES}/${TMP_ARCHIVE_FOLDER} || exit 1
+
+		apply_patches ${COMMON_PATCHES}/ntp
 
 		cd ${TARGET_BUILD} || exit 1
 		mkdir ntp

--- a/set_env.sh
+++ b/set_env.sh
@@ -34,6 +34,7 @@ else
 
 		export COMMON_HOME="${BASE_DIR}/targets/common"
 		export COMMON_CONFIG="${COMMON_HOME}/config"
+		export COMMON_PATCHES="${COMMON_CONFIG}/patches"
 		export COMMON_DOWNLOAD="${COMMON_HOME}/download"
 
 		source ${TARGET_CONFIG}/config.sh

--- a/targets/common/config/config.sh
+++ b/targets/common/config/config.sh
@@ -19,7 +19,7 @@ SRC_PACKAGE_BUILD_LIBXML2="@COMMON@""http://xmlsoft.org/sources/libxml2-2.9.10.t
 
 SRC_PACKAGE_BINUTILS="@COMMON@""https://ftp.gnu.org/gnu/binutils/binutils-2.36.1.tar.xz"
 
-SRC_PACKAGE_GCC="@COMMON@""https://ftp.gnu.org/gnu/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz"
+SRC_PACKAGE_GCC="@COMMON@""https://ftp.gnu.org/gnu/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz"
 SRC_PACKAGE_GCC_MPFR="@COMMON@""https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
 SRC_PACKAGE_GCC_GMP="@COMMON@""https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz"
 SRC_PACKAGE_GCC_MPC="@COMMON@""https://ftp.gnu.org/gnu/mpc/mpc-1.2.1.tar.gz"
@@ -29,7 +29,7 @@ SRC_PACKAGE_GCC_CLOOG="@COMMON@""ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-
 SRC_PACKAGE_LIBTIRPC="@COMMON@""https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.1.tar.bz2"
 SRC_PACKAGE_LIBNSL="@COMMON@""https://github.com/thkukuk/libnsl/releases/download/v1.3.0/libnsl-1.3.0.tar.xz"
 
-SRC_PACKAGE_GLIBC="@COMMON@""https://ftp.gnu.org/gnu/glibc/glibc-2.33.tar.xz"
+SRC_PACKAGE_GLIBC="@COMMON@""https://ftp.gnu.org/gnu/glibc/glibc-2.34.tar.xz"
 
 SRC_PACKAGE_BUSYBOX="@COMMON@""https://busybox.net/downloads/busybox-1.33.0.tar.bz2"
 SRC_PACKAGE_UTILLINUX="@COMMON@""https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.tar.xz"

--- a/targets/common/config/patches/ntp/0001-libntp-not-use-PTHREAD_STACK_MIN-on-glibc.patch
+++ b/targets/common/config/patches/ntp/0001-libntp-not-use-PTHREAD_STACK_MIN-on-glibc.patch
@@ -1,0 +1,12 @@
+diff -uNr --no-dereference a/libntp/work_thread.c b/libntp/work_thread.c
+--- a/libntp/work_thread.c	2021-10-08 08:53:01.483747945 +0200
++++ b/libntp/work_thread.c	2021-10-08 08:53:39.453397535 +0200
+@@ -41,7 +41,7 @@
+ #ifndef THREAD_MINSTACKSIZE
+ # define THREAD_MINSTACKSIZE	(64U * 1024)
+ #endif
+-#ifndef __sun
++#if !defined(__sun) && !defined(__GLIBC__)
+ #if defined(PTHREAD_STACK_MIN) && THREAD_MINSTACKSIZE < PTHREAD_STACK_MIN
+ # undef THREAD_MINSTACKSIZE
+ # define THREAD_MINSTACKSIZE PTHREAD_STACK_MIN


### PR DESCRIPTION
Update version of GCC and GLIBC to fix compilation error on Raspberry Pi Zero compilation/
Add missing package to compile samba (in README.md)
Fix compilation of ntp package (maybe due to gcc update). Add a function to apply patch from directory.